### PR TITLE
More README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ in {
 fmapExample =
   { parent     = "rawExample",
     outputType = MyOutput,
-    f          = \(i: ParentInput) ->
-                   { extended = "${i.name}. How are you?" }
+    f          = \(i: ParentOutput) ->
+                   { extended = "${i.greeting}. How are you?" }
   }
 }
 ```


### PR DESCRIPTION
The `f` of `Fmap` API works over it's parent's output type, not its input. Oops!