### PR TITLE
Proof of concept repl

### DIFF
--- a/dhallia.cabal
+++ b/dhallia.cabal
@@ -11,6 +11,7 @@ cabal-version:      >= 1.10
 library
   exposed-modules:  API
                     BuiltinHTTP
+                    Repl
   hs-source-dirs:   src
   build-depends:    base             >= 4.11 && < 4.13
                   , aeson

--- a/examples/cat-facts.dhall
+++ b/examples/cat-facts.dhall
@@ -36,6 +36,14 @@ in
       fromResponse = +1
     },
 
+  just-the-facts =
+    let List/map = https://prelude.dhall-lang.org/List/map
+    in
+    { parent = "cat-facts",
+      f = \(facts: { all : List ListFact} ) -> List/map ListFact Text (\(m : ListFact) -> m.text) facts.all,
+      outputType = List Text
+    },
+
   cat-fact =
     { inputType  = { _id : Text },
       outputType = Fact,

--- a/src/API.hs
+++ b/src/API.hs
@@ -246,3 +246,15 @@ test3 = do
   r <- case Dhall.Map.lookup "mw-search" (getAPIs x) of
     Just api -> runReaderT (runRequests api exampleInput) mgr
   maybe (error "response error") (print . Dhall.Pretty.prettyExpr) r
+
+
+test4 :: IO String
+test4 = do
+  mgr <- HTTPS.newTlsManager
+  x <- Dhall.inputExpr "./examples/cat-facts.dhall"
+  let deps = dependencyGraph x
+  Monad.when (topSort deps == Nothing) (error  "found a cycle")
+  exampleInput <- Dhall.inputExpr "{}"
+  r <- case Dhall.Map.lookup "just-the-facts" (getAPIs x) of
+    Just api -> runReaderT (runRequests api exampleInput) mgr
+  maybe (error "response error") (return . show . Dhall.Pretty.prettyExpr) r

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -1,0 +1,77 @@
+module Repl where
+
+import qualified Control.Monad.Reader    as Monad
+import qualified Control.Monad.IO.Class  as IO
+import qualified Network.HTTP.Client     as HTTP
+import qualified Data.Text               as Text
+import           Data.Text               (Text)
+import qualified Network.HTTP.Client.TLS as HTTP
+import qualified System.Console.Repline  as R
+import qualified Data.IORef              as IORef
+import qualified Dhall.Map
+import qualified Dhall
+import qualified Dhall.Core as Dhall
+import qualified Dhall.Pretty as Dhall
+
+import qualified Data.List as List
+
+import API (A, getAPIs, runRequests)
+
+data Env = Env
+  { manager :: HTTP.Manager
+  , apis    :: IORef.IORef (Dhall.Map.Map Text.Text A)
+    -- cache :: DhalliaCache -- TODO
+  }
+
+cmd :: String -> Repl ()
+cmd c = do
+  let (apiName, apiArgument) = List.break (== ' ') c
+  env  <- Monad.ask
+  apis <- IO.liftIO (IORef.readIORef (apis env))
+  case Dhall.Map.lookup (Text.pack apiName) apis of
+    Nothing  -> error ("No such api: " <> apiName)
+    Just api -> do
+      dhallInput <- IO.liftIO $ Dhall.inputExpr (Text.pack apiArgument)
+      Just r <- IO.liftIO $ Monad.runReaderT (runRequests api dhallInput) (manager env)
+      IO.liftIO (print $ Dhall.prettyExpr r)
+      return ()
+
+                      
+
+options :: [(String, [String] -> Repl ())]
+options =
+  [("load", loadAPIs)
+  ,("list", listAPIs)
+  ,("quit", error "Bye")
+  ]
+
+loadAPIs :: [String] -> Repl ()
+loadAPIs [expr] = do
+  apisRef <- Monad.asks apis
+  newAPIs <- IO.liftIO $ Dhall.inputExpr (Text.pack expr)
+  case newAPIs of
+    Dhall.RecordLit e -> IO.liftIO $ IORef.modifyIORef apisRef (<> getAPIs newAPIs) >> putStrLn "Success"
+
+listAPIs :: [String] -> Repl ()
+listAPIs [] = do
+  apisRef <- Monad.asks apis
+  apis    <- IO.liftIO $ IORef.readIORef apisRef
+  IO.liftIO $ mapM_ (putStrLn . Text.unpack) (Dhall.Map.keys apis)
+
+completer :: Monad m => R.LineCompleter m
+completer = undefined
+
+ini :: Repl ()
+ini = IO.liftIO (print "Welcome!")
+
+type Repl a = R.HaskelineT (Monad.ReaderT Env IO) a
+
+repl :: IO ()
+repl = do
+  mgr  <- HTTP.newTlsManager
+  apis <- IORef.newIORef mempty
+  Monad.runReaderT
+    (R.evalRepl
+      (pure "❀> ") cmd options (Just ':') (R.Cursor completer) ini
+    ) (Env mgr apis)
+


### PR DESCRIPTION
Oh hells yes!

```
*API Repl> repl
"Welcome!"
❀> :load ./examples/cat-facts.dhall
Success
❀> cat-fact { _id = "5d3e2191484b54001508b0df" }
{ _id = "5d3e2191484b54001508b0df", text = "Cats can be nation president." }
```

No proper error handling is done in this PR - consistent with the style of the rest of the repo :)

I guess I do wonder though, should we be implementing our own repl in `repline`, or should we be somehow piggybacking on dhall's own repl. I'm implementing my own here to experiment with type-driven tab completion (not started yet).

But if we abandon that and use dhall's repl, then the user can assign results to variables and manipulate them with functions - that would be a great experience for users who are implementing/debugging their own dhallia wrapper code.