### PR TITLE
Add basic caching

### DIFF
--- a/config/request.dhall
+++ b/config/request.dhall
@@ -10,6 +10,8 @@ let Request =
 
 let QueryParam = { key: Text, value: Text }
 
+let Cache = { ttlSeconds : Integer }
+
 let defaultRequest : Request =
   { baseUrl       = "example.com",
     verb          = "GET",

--- a/dhallia.cabal
+++ b/dhallia.cabal
@@ -10,7 +10,10 @@ cabal-version:      >= 1.10
 
 library
   exposed-modules:  Dhallia.API
+                    Dhallia.Cache
+                    Dhallia.Cache.InMemory
                     Dhallia.Check
+                    Dhallia.Expr
                     Dhallia.Interpreter.HTTPClient
                     Dhallia.Interpreter.Repl
   hs-source-dirs:   src
@@ -28,6 +31,7 @@ library
                   , repline
                   , row-types
                   , text
+                  , time
   default-language: Haskell2010
 
 executable test-server

--- a/examples/cat-facts.dhall
+++ b/examples/cat-facts.dhall
@@ -49,6 +49,15 @@ in
       toRequest = \(i: { _id : Text }) ->
         Req.addPathPart
 	  i._id
-	  (Req.default // { baseUrl = url })
+	  (Req.default // { baseUrl = url }),
+      cache = Some { ttlSeconds = +3600 }
+    },
+
+  cat-fact-by-string =
+    { inputType = Text,
+      parent = "cat-fact",
+      f = \(t: Text) -> { _id = t },
+      cache = Some { ttlSeconds = +3600 }
     }
+
 }

--- a/src/Dhallia/Cache.hs
+++ b/src/Dhallia/Cache.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Dhallia.Cache where
+
+import qualified Data.Time as Time
+import qualified Dhall
+import GHC.Generics (Generic)
+
+import Dhallia.Expr
+
+data Cache m = Cache
+  { set      :: Expr -> Expr -> m ()
+  , unset    :: Expr         -> m ()
+  , unsetAll ::                 m ()
+  , get      :: Expr         -> m (Maybe Expr)
+  , stats    ::                 m Stats
+  }
+
+data Stats = Stats
+  { cacheEntries :: Int
+  } deriving (Eq, Show)
+
+nullCache :: Monad m => Cache m
+nullCache = Cache
+  { set      = \_ _ -> return ()
+  , unset    = \_   -> return ()
+  , unsetAll =         return ()
+  , get      = \_   -> return Nothing
+  , stats    =         return (Stats 0)
+  }
+
+data CacheInfo = CacheInfo
+  { ttlSeconds :: Integer
+  } deriving (Eq, Generic, Show)
+
+instance Dhall.FromDhall CacheInfo
+
+cacheType :: Dhall.Type CacheInfo
+cacheType = Dhall.autoWith Dhall.defaultInterpretOptions

--- a/src/Dhallia/Cache/InMemory.hs
+++ b/src/Dhallia/Cache/InMemory.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+
+module Dhallia.Cache.InMemory where
+
+import qualified Control.Monad.IO.Class as IO
+import qualified Data.Time.Clock as Time
+import qualified Data.Time as Time
+import qualified Data.IORef as IORef
+import qualified Data.Map   as Map
+
+import Dhallia.Expr
+import Dhallia.Cache
+
+data InMemoryCache = InMemoryCache
+  { store            :: Map.Map Expr (Expr, Time.UTCTime)
+  , lastInvalidation :: Time.UTCTime
+  } deriving (Show)
+
+emptyCache :: InMemoryCache
+emptyCache = InMemoryCache
+  { store            = mempty
+  , lastInvalidation = Time.UTCTime
+      { utctDay     = Time.fromGregorian 1979 1 1
+      , utctDayTime = 0
+      }
+  }
+
+
+makeInMemory :: IO.MonadIO m => CacheInfo -> IO (Cache m)
+makeInMemory (CacheInfo ttlSeconds) = do
+  c <- IORef.newIORef emptyCache
+
+  let set k v = IO.liftIO $ do
+        now <- Time.getCurrentTime
+        let deadline = Time.addUTCTime (fromIntegral ttlSeconds) now
+        IORef.modifyIORef c $ \InMemoryCache{..} ->
+          InMemoryCache { store = Map.insert k (v, deadline) store, .. }
+
+      get k   = IO.liftIO $ do
+        now <- Time.getCurrentTime
+        IORef.atomicModifyIORef c $ \InMemoryCache{..} ->
+          case Map.lookup k store of
+
+            -- No cache hit, no update needed
+            Nothing -> (InMemoryCache{..}, Nothing)
+
+            -- Cache hit when ttl expired, delete the key
+            Just (_, ttlDeadline) |
+              (lastInvalidation > ttlDeadline || now > ttlDeadline) ->
+              (InMemoryCache { store = Map.delete k store, .. }, Nothing )
+
+            -- Cache hit with ttl valid, return the key
+            Just (v, ttlDeadline) | otherwise -> (InMemoryCache{..}, Just v)
+
+      unsetAll = IO.liftIO $ do
+        now <- Time.getCurrentTime
+        let deadline = Time.addUTCTime (fromIntegral ttlSeconds) now
+        IORef.modifyIORef c $ \InMemoryCache{..} ->
+          InMemoryCache { lastInvalidation = deadline, .. }
+
+      unset k = IO.liftIO $ do
+        IORef.modifyIORef c $ \InMemoryCache{..} ->
+          InMemoryCache { store = Map.delete k store, ..}
+
+      stats = IO.liftIO $ IORef.readIORef c >>= \InMemoryCache{..} ->
+        return (Stats { cacheEntries = Map.size store })
+  return $ Cache { set, get, unsetAll, unset, stats }

--- a/src/Dhallia/Expr.hs
+++ b/src/Dhallia/Expr.hs
@@ -1,0 +1,8 @@
+module Dhallia.Expr where
+
+import qualified Dhall
+import qualified Dhall.Core
+import qualified Dhall.Src  (Src)
+import           Data.Void  (Void)
+
+type Expr = Dhall.Core.Expr Dhall.Src.Src Void

--- a/src/Dhallia/Interpreter/Repl.hs
+++ b/src/Dhallia/Interpreter/Repl.hs
@@ -17,10 +17,12 @@ import qualified Data.List as List
 
 import Dhallia.API
 import Dhallia.Interpreter.HTTPClient
+import Dhallia.Cache
+import Dhallia.Cache.InMemory
 
 data Env = Env
   { manager :: HTTP.Manager
-  , apis    :: IORef.IORef (Map.Map Text.Text API)
+  , apis    :: IORef.IORef (Map.Map Text.Text (API (Cache IO)))
     -- cache :: DhalliaCache -- TODO
   }
 
@@ -50,8 +52,9 @@ loadAPIs :: [String] -> Repl ()
 loadAPIs [expr] = do
   apisRef <- Monad.asks apis
   newAPIs <- IO.liftIO $ Dhall.inputExpr (Text.pack expr)
+  newAPIs' <- IO.liftIO $ getAPIs makeInMemory newAPIs
   case newAPIs of
-    Dhall.RecordLit e -> IO.liftIO $ IORef.modifyIORef apisRef (<> getAPIs newAPIs) >> putStrLn "Success"
+    Dhall.RecordLit e -> IO.liftIO $ IORef.modifyIORef apisRef (<> newAPIs') >> putStrLn "Success"
 
 listAPIs :: [String] -> Repl ()
 listAPIs [] = do


### PR DESCRIPTION
Add the ability to configure caches in api specs.
Build in-memory caches for apis that want them.
Use caches during http requests.