### PR TITLE
Tab-completion for commands and loaded apis

### DIFF
--- a/dhallia.cabal
+++ b/dhallia.cabal
@@ -25,6 +25,7 @@ library
                   , http-client-tls
                   , lens-family-core
                   , mtl
+                  , haskeline
                   , repline
                   , row-types
                   , text

--- a/src/Dhallia/API.hs
+++ b/src/Dhallia/API.hs
@@ -35,8 +35,6 @@ import qualified Dhall.Src
 import qualified Dhall.TypeCheck
 
 
-import           BuiltinHTTP
-
 data API =
     Raw RawAPI
   -- | Cmap CmapAPI


### PR DESCRIPTION
Improve tab completion in repl:
 - Commands like `:load` and `:list` tab complete
 - Names of loaded apis tab complete