### PR TITLE
No normalizeM

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -17,11 +17,14 @@ allCabalHashesOverlay = self: super: {
    };
   };
 
-  nixpkgs =
-    import
-    (builtins.fetchTarball "https://github.com/nixos/nixpkgs/archive/${nixpkgs_rev}.tar.gz") {
-    overlays = [ allCabalHashesOverlay ];
-    };
+  # nixpkgs =
+  #   import
+  #   (builtins.fetchTarball "https://github.com/nixos/nixpkgs/archive/${nixpkgs_rev}.tar.gz") {
+  #   overlays = [ allCabalHashesOverlay ];
+  #   };
+
+  nixpkgs = import  <nixpkgs> { overlays = [allCabalHashesOverlay]; };
+
   inherit (nixpkgs) pkgs;
 
   dhallSrc = pkgs.fetchFromGitHub {

--- a/src/Dhallia/API.hs
+++ b/src/Dhallia/API.hs
@@ -202,16 +202,17 @@ getCache (Merge MergeAPI{cache})   = cache
 showRequests :: IO.MonadIO m => API c -> Expr -> m ()
 showRequests = showRequestsWith preludeNormalizer
 
-showRequestsWith :: (IO.MonadIO m) => Dhall.Core.NormalizerM m Void -> API c -> Expr -> m ()
+showRequestsWith :: (IO.MonadIO m) => Dhall.Core.Normalizer Void -> API c -> Expr -> m ()
 showRequestsWith n api' inputE = do
+  let n' = Just $ Dhall.Core.ReifiedNormalizer n
   case api' of
 
     Raw RawAPI{toRequest} -> do
-      req <- Dhall.Core.normalizeWithM n (Dhall.Core.App toRequest inputE)
+      let req = Dhall.Core.normalizeWith n' (Dhall.Core.App toRequest inputE)
       IO.liftIO . print . Dhall.Pretty.prettyExpr $ req
 
     MapIn MapInAPI{f,parent} -> do
-      requestInput <- Dhall.Core.normalizeWithM n (Dhall.Core.App f inputE)
+      let requestInput = Dhall.Core.normalizeWith n' (Dhall.Core.App f inputE)
       showRequestsWith n parent requestInput
 
     MapOut MapOutAPI{parent} ->

--- a/src/Dhallia/API.hs
+++ b/src/Dhallia/API.hs
@@ -1,3 +1,18 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      : Dhallia.API
+-- Description : The encoding of APIs in dhall syntax-}
+-- Copyright   : (c) Greg Hale 2019
+-- License     : BSD-3-Clause
+-- Maintainer  : imalsogreg@gmail.com
+-- Stability   : experimental
+-- Portability : Posix
+
+-- API definitions are specified in Dhall (with some dhallia extensions).
+-- This module defines the types of APIs that can be defined (Raw, MapIn, Merge, etc),
+-- and the method for decoding them from Dhall into Haskell.
+--------------------------------------------------------------------------------
+
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
@@ -26,8 +41,8 @@ import qualified Dhall.Map              as Map
 import qualified Dhall.Pretty
 
 import           Dhallia.Cache
-import           Dhallia.Prelude (preludeContext, preludeNormalizer)
 import           Dhallia.Expr           (Expr)
+import           Dhallia.Prelude        (preludeContext, preludeNormalizer)
 
 
 data API c =
@@ -36,7 +51,6 @@ data API c =
   | MapOut (MapOutAPI c)
   | Merge  (MergeAPI c)
   deriving (Eq, Show)
-
 
 
 data RawAPI c = RawAPI

--- a/src/Dhallia/Expr.hs
+++ b/src/Dhallia/Expr.hs
@@ -17,7 +17,6 @@
 
 module Dhallia.Expr (
   Expr
-  , inputExprWithM
   ) where
 
 import qualified Control.Monad.IO.Class     as IO
@@ -37,20 +36,3 @@ import qualified Lens.Family
 -- | Our @Expr@ specializes the one from @Dhall@ with the assumption
 --   that expressions still have source spans and all imports have been resolved
 type Expr = Dhall.Expr Src Void
-
--- |
-inputExprWithM
-  :: IO.MonadIO m => Dhall.NormalizerM m Void
-  -> Dhall.Context Expr
-  -> Text
-  -> m Expr
-inputExprWithM n ctx txt = do
-  let settings = Dhall.defaultInputSettings
-  expr <- Dhall.throws (Dhall.Parser.exprFromText (Lens.Family.view Dhall.sourceName settings) txt)
-  let ctx' = List.foldl' (\acc (k,v) -> Dhall.insert k v acc)
-                         (Lens.Family.view Dhall.startingContext settings)
-                         (Dhall.toList ctx)
-  let status = Lens.Family.set Dhall.Import.startingContext ctx (Dhall.Import.emptyStatus ".")
-  expr' <- IO.liftIO $ State.evalStateT (Dhall.Import.loadWith expr) status
-  _ <- Dhall.throws (Dhall.TypeCheck.typeWith ctx' expr')
-  Dhall.normalizeWithM n expr'

--- a/src/Dhallia/Expr.hs
+++ b/src/Dhallia/Expr.hs
@@ -1,41 +1,56 @@
-{-# LANGUAGE RankNTypes      #-}
-{-# LANGUAGE RecordWildCards #-}
+--------------------------------------------------------------------------------
+-- |
+-- Module : Dhallia.Expr
+-- Copyright : (c) Greg Hale 2019
+-- License   : BSD-3-Clause
+-- Maintainer : imalsogreg@gmail.com
+-- Stability : Experimental
+-- Portability : posix
+--
+-- A custom version of Dhall's @inputExprWithM@ that allows normalization to
+-- happen within a monad.
+-- Dhall's buildin `inputExprWith` forces the use of pure normalizers
+--------------------------------------------------------------------------------
 
-module Dhallia.Expr where
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 
-import qualified Control.Monad.IO.Class as IO
-import qualified Control.Monad.State.Strict    as State
-import qualified Data.List              as List
-import           Data.Text              (Text)
-import           Data.Void              (Void)
+module Dhallia.Expr (
+  Expr
+  , inputExprWithM
+  ) where
+
+import qualified Control.Monad.IO.Class     as IO
+import qualified Control.Monad.State.Strict as State
+import qualified Data.List                  as List
+import           Data.Text                  (Text)
+import           Data.Void                  (Void)
 import qualified Dhall
-import qualified Dhall.Context          as Dhall
-import qualified Dhall.Core             as Dhall
+import qualified Dhall.Context              as Dhall
+import qualified Dhall.Core                 as Dhall
 import qualified Dhall.Import
 import qualified Dhall.Parser
-import           Dhall.Src              (Src)
+import           Dhall.Src                  (Src)
 import qualified Dhall.TypeCheck
 import qualified Lens.Family
 
+-- | Our @Expr@ specializes the one from @Dhall@ with the assumption
+--   that expressions still have source spans and all imports have been resolved
 type Expr = Dhall.Expr Src Void
 
+-- |
 inputExprWithM
   :: IO.MonadIO m => Dhall.NormalizerM m Void
   -> Dhall.Context Expr
   -> Text
-  -> m (Dhall.Expr Src Void)
+  -> m Expr
 inputExprWithM n ctx txt = do
   let settings = Dhall.defaultInputSettings
-  -- IO.liftIO $ print "About to exprFromText"
   expr <- Dhall.throws (Dhall.Parser.exprFromText (Lens.Family.view Dhall.sourceName settings) txt)
   let ctx' = List.foldl' (\acc (k,v) -> Dhall.insert k v acc)
                          (Lens.Family.view Dhall.startingContext settings)
                          (Dhall.toList ctx)
   let status = Lens.Family.set Dhall.Import.startingContext ctx (Dhall.Import.emptyStatus ".")
-  -- IO.liftIO $ print "About to load"
   expr' <- IO.liftIO $ State.evalStateT (Dhall.Import.loadWith expr) status
-  -- expr' <- IO.liftIO $ Dhall.Import.load expr
-  -- IO.liftIO $ print "About to typecheck"
   _ <- Dhall.throws (Dhall.TypeCheck.typeWith ctx' expr')
-  -- IO.liftIO $ print "About to normalize"
   Dhall.normalizeWithM n expr'

--- a/src/Dhallia/Interpreter/HTTPClient.hs
+++ b/src/Dhallia/Interpreter/HTTPClient.hs
@@ -15,6 +15,7 @@ import           Control.Monad.Reader    (ReaderT, ask, runReaderT)
 import qualified Data.Aeson              as Aeson
 import qualified Data.ByteString.Lazy    as LazyByteString
 import qualified Data.CaseInsensitive    as CI
+import           Data.Proxy              (Proxy (..))
 import qualified Data.Text               as Text
 import qualified Data.Text.Encoding      as Text
 import           Data.Void               (Void)
@@ -31,7 +32,7 @@ import           Dhallia.API
 import           Dhallia.Cache
 import           Dhallia.Cache.InMemory
 import           Dhallia.Expr
-import           Dhallia.Prelude         (preludeContext, preludeNormalizer)
+import           Dhallia.Prelude         (inputExpr, preludeNormalizer)
 
 request :: Dhall.Type Request
 request = Dhall.record $
@@ -173,7 +174,7 @@ runHTTP Request{..} = do
 test :: IO ()
 test = do
   mgr <- HTTPS.newTlsManager
-  x <- inputExprWithM preludeNormalizer preludeContext "./config/api.dhall"
+  x <- inputExpr "./config/api.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
 
@@ -188,7 +189,7 @@ test = do
 test2 :: IO ()
 test2 = do
   mgr <- HTTPS.newTlsManager
-  x <- inputExprWithM preludeNormalizer preludeContext "./examples/cat-facts.dhall"
+  x <- inputExpr "./examples/cat-facts.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
   exampleInput <- Dhall.inputExpr "{ _id = \"5d3e2191484b54001508b0df\" }"
@@ -202,7 +203,7 @@ test2 = do
 test3 :: IO ()
 test3 = do
   mgr <- HTTPS.newTlsManager
-  x <- Dhall.inputExpr "./examples/metaweather.dhall"
+  x <- inputExpr "./examples/metaweather.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
   exampleInput <- Dhall.inputExpr "\"san\""
@@ -216,7 +217,7 @@ test3 = do
 test4 :: IO String
 test4 = do
   mgr <- HTTPS.newTlsManager
-  x <- Dhall.inputExpr "./examples/cat-facts.dhall"
+  x <- inputExpr "./examples/cat-facts.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
   exampleInput <- Dhall.inputExpr "{}"
@@ -229,7 +230,7 @@ test4 = do
 test5 :: IO String
 test5 = do
   mgr <- HTTPS.newTlsManager
-  x <- Dhall.inputExpr "../upstream/DFE_v8.dhall"
+  x <- inputExpr "../upstream/DFE_v8.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
   exampleInput <- Dhall.inputExpr "{ location = \"3801,2042,2224,758,254,1765,1536,1339,2754,2239,1354,1204,2739,83,2187,2426,1459,875,80,2243,770,1766,2237,1116,1368,1922,1962,1836,1430,2438,801,1837,1523,1531,1490,2093,1979,1953,1770,2112,1852,2429,2278,2342,1981,176,2572,2425,1785,1514,1061,2334,2220,2190,2467,1506,771,219,2374,2803,824\", tcin = \"75665658\", partial = True, horizon = \"5d1\" }"
@@ -245,7 +246,7 @@ test5 = do
 test6 :: IO ()
 test6 = do
   mgr <- HTTPS.newTlsManager
-  x <- inputExprWithM preludeNormalizer preludeContext "./examples/cat-facts.dhall"
+  x <- inputExpr "./examples/cat-facts.dhall"
   let deps = dependencyGraph x
   Monad.when (Graph.topSort deps == Nothing) (error  "found a cycle")
   exampleInput <- Dhall.inputExpr "\"5d3e2191484b54001508b0df\""

--- a/src/Dhallia/Interpreter/Repl.hs
+++ b/src/Dhallia/Interpreter/Repl.hs
@@ -21,7 +21,7 @@ import           Dhallia.API
 import           Dhallia.Cache
 import           Dhallia.Cache.InMemory
 import           Dhallia.Interpreter.HTTPClient
-import  Dhallia.Prelude (preludeContext, preludeNormalizer)
+import  Dhallia.Prelude (inputExpr)
 import Dhallia.Expr
 
 
@@ -40,7 +40,7 @@ cmd c = do
   case Map.lookup (Text.pack apiName) apis of
     Nothing  -> error ("No such api: " <> apiName)
     Just api -> do
-      dhallInput <- IO.liftIO $ inputExprWithM preludeNormalizer preludeContext (Text.pack apiArgument)
+      dhallInput <- IO.liftIO $ inputExpr (Text.pack apiArgument)
       Just r <- IO.liftIO $ Monad.runReaderT (runRequests api dhallInput) (manager env)
       IO.liftIO (print $ Dhall.prettyExpr r)
       return ()
@@ -58,7 +58,7 @@ options =
 loadAPIs :: [String] -> Repl ()
 loadAPIs [expr] = do
   apisRef <- Monad.asks apis
-  newAPIs <- IO.liftIO $ inputExprWithM preludeNormalizer preludeContext (Text.pack expr)
+  newAPIs <- IO.liftIO $ inputExpr (Text.pack expr)
   newAPIs' <- IO.liftIO $ getAPIs makeInMemory newAPIs
   case newAPIs of
     Dhall.RecordLit e -> IO.liftIO $ IORef.modifyIORef apisRef (newAPIs' <>) >> putStrLn "Success"

--- a/src/Dhallia/Prelude.hs
+++ b/src/Dhallia/Prelude.hs
@@ -1,30 +1,45 @@
--- | Extra functions useful for transforming API data
+-- | Extra values useful for transforming API data
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 module Dhallia.Prelude where
 
 import qualified Control.Monad.IO.Class as IO
 import qualified Data.List              as List
+import           Data.Proxy             (Proxy (..))
+import qualified Data.Text              as Text
+import qualified Data.Time              as Time
+import qualified Data.Time.Calendar     as Time
 import           Data.Void              (Void)
 import qualified Dhall
 import qualified Dhall.Context          as Dhall
 import qualified Dhall.Core             as Dhall
+import qualified Dhall.Map
 import qualified Dhall.Src              as Dhall
 
 import           Dhallia.Expr
 
-preludeContext :: Dhall.Context Expr
-preludeContext =
+inputExpr :: forall m. IO.MonadIO m => Text.Text -> m (Dhall.Expr Dhall.Src Void)
+inputExpr txt = inputExprWithM preludeNormalizer (preludeContext (Proxy @m)) txt
+
+preludeContext :: forall m.Monad m => Proxy m -> Dhall.Context Expr
+preludeContext _ =
   List.foldl' (\acc (k,v) -> Dhall.insert k v acc) Dhall.empty preludeTypes
   where
-    preludeTypes = (\(DhalliaFunction{..} :: DhalliaFunction IO Void) -> (df_name, df_type)) <$> [ stringEquality ]
+    preludeTypes :: [(Dhall.Text, Dhall.Expr Dhall.Src Void)]
+    preludeTypes =
+      (("day", day) :) $
+      (\(DhalliaValue{..}) -> (df_name, df_type)) <$> [ parseDay @m, stringEquality ]
+
 
 preludeNormalizer :: (Monad m, Eq a) => Dhall.NormalizerM m a
-preludeNormalizer e0 = run [stringEquality]
+preludeNormalizer e0 = run [parseDay, stringEquality]
   where
     run []     = return Nothing
     run (x:xs) = do
@@ -33,14 +48,16 @@ preludeNormalizer e0 = run [stringEquality]
         Nothing  -> run xs
         Just res -> return (Just res)
 
-data DhalliaFunction m a = DhalliaFunction
+
+data DhalliaValue m a = DhalliaValue
   { df_type :: Dhall.Expr Dhall.Src Void
   , df_norm :: Dhall.NormalizerM m a
   , df_name :: Dhall.Text
   }
 
-stringEquality :: Monad m => DhalliaFunction m a
-stringEquality = DhalliaFunction
+
+stringEquality :: Monad m => DhalliaValue m a
+stringEquality = DhalliaValue
   { df_type = Dhall.Pi "_" Dhall.Text (Dhall.Pi "_" Dhall.Text Dhall.Bool)
   , df_name = "Text/equal"
   , df_norm = \case
@@ -50,3 +67,55 @@ stringEquality = DhalliaFunction
                  -> return . Just . Dhall.BoolLit $ x == y
       _ -> return Nothing
   }
+
+
+day :: Dhall.Expr Dhall.Src Void
+day = Dhall.Record
+  (Dhall.Map.fromList
+    [("year",   Dhall.Integer)
+    , ("month", Dhall.Integer)
+    , ("day",   Dhall.Integer)
+    ])
+
+parseDay :: Monad m => DhalliaValue m a
+parseDay = DhalliaValue
+  { df_type = Dhall.Pi "_" Dhall.Text day
+  , df_name = "Day/parse"
+  , df_norm = \e -> case (viewDateArgString e) >>= parse of
+      Just t  -> return $ Just $ mkDay t
+      Nothing -> return Nothing
+      }
+  where
+
+    viewDateArgString :: Dhall.Expr s a -> Maybe Text.Text
+    viewDateArgString
+      (Dhall.App (Dhall.Var "Day/parse")
+        (Dhall.TextLit (Dhall.Chunks _ x))) = Just x
+    viewDateArgString _ = Nothing
+
+    parse :: Text.Text -> Maybe Time.Day
+    parse = Time.parseTimeM @Maybe False Time.defaultTimeLocale "%Y-%m-%d" . Text.unpack
+
+    mkDay :: Time.Day -> Dhall.Expr s a
+    mkDay (Time.toGregorian -> (y,m,d)) = Dhall.RecordLit
+      (Dhall.Map.fromList
+       [("year",  mkNat y)
+       ,("month", mkNat m)
+       ,("day",   mkNat d)
+       ])
+      where
+        mkNat :: Integral i => i -> Dhall.Expr s a
+        mkNat = Dhall.IntegerLit . fromIntegral
+
+
+-- range :: Monad m => DhalliaValue m a
+-- range = DhalliaValue
+--   { df_type = Dhall.Pi "_" Dhall.Natural (Dhall.Pi "_" Dhall.Natural (Dhall.list Dhall.Natural))
+--   , df_name = "List/range"
+--   , df_norm = \e -> case e of
+--       Dhall.App
+--        (Dhall.App (Dhall.Var "List/range")
+--                   (Dhall.NaturalLit i0))
+--           (Dhall.NaturalLit i1)
+--         -> Dhall.ListLit Nothing [Dhall.NaturalLit i | i <- [i0..i1]]
+  -- }


### PR DESCRIPTION
I was under the impression that normalization for dhallia would need to happen in `IO` - probably this notion is left over from when I thought that `runRequest` would need to be a dhall builtin, and normalizing that would need to happen in IO.

But currently there is no need for `runRequest` in dhallia, since we define the input processing and the output processing separately in dhall config files, letting the request handling happen implicitly in the dhallia runtime.

So, this PR moves us from using the somewhat more annoying `normalizeWithM` to `normalizeWith`.